### PR TITLE
Improve: small tweaks

### DIFF
--- a/Native/Controller.swift
+++ b/Native/Controller.swift
@@ -7,6 +7,14 @@ import FormTextField
 class Controller: UITableViewController {
     let fields = Field.fields()
 
+    lazy var checkAccessoryView: UIImageView = {
+        let imageView = UIImageView(image: UIImage(named: "check-icon")!)
+        imageView.contentMode = .Center
+        imageView.frame = CGRect(x: 0, y: 0, width: 30, height: 20)
+
+        return imageView
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = UIColor(red: 239/255, green: 239/255, blue: 244/255, alpha: 1)
@@ -38,12 +46,6 @@ class Controller: UITableViewController {
             cell.textField.inputValidator = field.inputValidator
             cell.textField.formatter = field.formatter
 
-            if field.inputType == .Email {
-                cell.textField.accessoryImage = UIImage(named: "check-icon")
-                cell.textField.isUsingClearButton = false
-                cell.textField.showAccessoryViewMode = .Always
-            }
-
             return cell
         }
     }
@@ -72,6 +74,16 @@ class Controller: UITableViewController {
                 let validField = cell.textField.validate()
                 if validField == false {
                     valid = validField
+                }
+
+                if field.inputType == .Email {
+                    if valid {
+                        cell.textField.accessoryView = self.checkAccessoryView
+                        cell.textField.showAccessoryViewMode = .Always
+                    } else {
+                        cell.textField.accessoryView = nil
+                        cell.textField.showAccessoryViewMode = .WhileEditing
+                    }
                 }
             }
         }

--- a/Native/Field.swift
+++ b/Native/Field.swift
@@ -32,7 +32,7 @@ struct Field {
         let requiredInputValidator = InputValidator(validation: requiredValidation)
 
         let emailField: Field = {
-            var field = Field(type: .Field, title: "Email adres")
+            var field = Field(type: .Field, title: "Email")
             field.inputType = .Email
 
             var validation = Validation()

--- a/Source/FormTextField.swift
+++ b/Source/FormTextField.swift
@@ -19,7 +19,6 @@ public class FormTextField: UITextField, UITextFieldDelegate {
     dynamic public var accessoryButtonColor: UIColor = UIColor(red: 0, green: 122/255, blue: 1, alpha: 1)
 
     dynamic public var accessoryImage: UIImage?
-    dynamic public var isUsingClearButton: Bool = true
     dynamic public var leftMargin : CGFloat = 10.0
     dynamic public var showAccessoryViewMode : UITextFieldViewMode = .WhileEditing { didSet { self.rightViewMode = self.showAccessoryViewMode } }
 
@@ -86,28 +85,16 @@ public class FormTextField: UITextField, UITextFieldDelegate {
     private lazy var customClearButton: UIButton? = {
         var button: UIButton? = nil
 
-        if self.isUsingClearButton {
-            let image = FormTextFieldClearButton.imageForSize(CGSize(width: 18, height: 18), color: self.accessoryButtonColor)
-            button = UIButton(type: .Custom)
-            button?.setImage(image, forState: .Normal)
-            button?.addTarget(self, action: #selector(FormTextField.clearButtonAction), forControlEvents: .TouchUpInside)
-            button?.frame = CGRect(x: 0, y: 0, width: FormTextField.AccessoryButtonWidth, height: FormTextField.AccessoryButtonHeight)
-        }
+        let image = FormTextFieldClearButton.imageForSize(CGSize(width: 18, height: 18), color: self.accessoryButtonColor)
+        button = UIButton(type: .Custom)
+        button?.setImage(image, forState: .Normal)
+        button?.addTarget(self, action: #selector(FormTextField.clearButtonAction), forControlEvents: .TouchUpInside)
+        button?.frame = CGRect(x: 0, y: 0, width: FormTextField.AccessoryButtonWidth, height: FormTextField.AccessoryButtonHeight)
 
         return button
     }()
 
-    private lazy var inputValidationIndicator: UIImageView? = {
-        var imageView: UIImageView? = nil
-
-        if let image = self.accessoryImage {
-            imageView = UIImageView(image: image)
-            imageView?.contentMode = .Center
-            imageView?.frame = CGRect(x: 0, y: 0, width: FormTextField.AccessoryButtonWidth, height: FormTextField.AccessoryButtonHeight)
-    }
-
-        return imageView
-    }()
+    public var accessoryView: UIView?
 
     override public var enabled: Bool {
         didSet {
@@ -154,7 +141,11 @@ public class FormTextField: UITextField, UITextFieldDelegate {
     }
 
     private func updateActive(active: Bool) {
-        self.rightView = self.valid ? self.inputValidationIndicator : self.customClearButton
+        if let accessoryView = self.accessoryView {
+            self.rightView = accessoryView
+        } else {
+            self.rightView = self.customClearButton
+        }
 
         if active {
             self.layer.backgroundColor = self.activeBackgroundColor.CGColor
@@ -181,12 +172,10 @@ public class FormTextField: UITextField, UITextFieldDelegate {
 
     private func updateValid(valid: Bool) {
         if valid {
-            self.rightView = self.inputValidationIndicator
             self.layer.backgroundColor = self.validBackgroundColor.CGColor
             self.layer.borderColor = self.validBorderColor.CGColor
             self.textColor = self.validTextColor
         } else {
-            self.rightView = self.customClearButton
             self.layer.backgroundColor = self.invalidBackgroundColor.CGColor
             self.layer.borderColor = self.invalidBorderColor.CGColor
             self.textColor = self.invalidTextColor
@@ -241,7 +230,11 @@ public class FormTextField: UITextField, UITextFieldDelegate {
 
 extension FormTextField {
     public func textFieldDidBeginEditing(textField: UITextField) {
-        self.rightView = self.valid ? self.inputValidationIndicator : self.customClearButton
+        if let accessoryView = self.accessoryView {
+            self.rightView = accessoryView
+        } else {
+            self.rightView = self.customClearButton
+        }
 
         self.updateActive(true)
     }


### PR DESCRIPTION
Simplifies the set up of a custom accessory view. It allows to use any view, it could be a button or an image view. Also it fallbacks to the old clear button when no accessory has been specified.
