### PR TITLE
Empty string in textField is not valid

### DIFF
--- a/Native/Controller.swift
+++ b/Native/Controller.swift
@@ -91,8 +91,10 @@ class Controller: UITableViewController {
     }
 
     func showCheckAccessory(textField: FormTextField) {
-        let valid = textField.validate()
+
+        let valid = textField.validate() // this function makes the textField set the accessoryView as its rightView
         if valid {
+            // here the accessory view is set for the first time
             textField.accessoryView = self.checkAccessoryView
             textField.accessoryViewMode = .Always
         } else {

--- a/Source/FormTextField.swift
+++ b/Source/FormTextField.swift
@@ -201,10 +201,6 @@ public class FormTextField: UITextField, UITextFieldDelegate {
             isValid = inputValidator.validateString(self.text ?? "")
         }
 
-        if self.text == "" {
-            isValid = false
-        }
-
         self.valid = isValid
         if self.enabled && updatingUI {
             self.updateValid(self.valid)

--- a/Source/FormTextField.swift
+++ b/Source/FormTextField.swift
@@ -150,6 +150,7 @@ public class FormTextField: UITextField, UITextFieldDelegate {
 
     private func updateActive(active: Bool) {
         if let accessoryView = self.accessoryView {
+            // accessoryView is set as the right view
             self.rightView = accessoryView
         } else if self.accessoryViewMode != .Never {
             self.rightView = self.clearButton

--- a/Source/FormTextField.swift
+++ b/Source/FormTextField.swift
@@ -200,6 +200,10 @@ public class FormTextField: UITextField, UITextFieldDelegate {
             isValid = inputValidator.validateString(self.text ?? "")
         }
 
+        if self.text == "" {
+            isValid = false
+        }
+
         self.valid = isValid
         if self.enabled && updatingUI {
             self.updateValid(self.valid)


### PR DESCRIPTION
Fixes issue #21

One more problem I encountered is that when a textField becomes valid for the first time the accessoryView get's set after the textField state is set to active. See comments in code.
